### PR TITLE
implement bs2-serialport as a protocol instead of a serialport abstraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,46 @@ function Protocol(options){
   });
 }
 
+//if opened before a bootload is attempted, opened at 200 intead of 9600
+Protocol.prototype.open = function(options, cb){
+  var serialport = this._serial;
+
+  function _open(){
+    return when.promise(function(resolve, reject) {
+      serialport.open( function(err){
+        if(err){ return reject(err); }
+        return resolve();
+      });
+    });
+  }
+
+  function onChunk(data) {
+    self.emit('data', data);
+  }
+
+  self._onResponse(onChunk);
+
+  var promise = _open();
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype.close = function(cb){
+  var serialport = this._serial;
+
+  function _close(){
+    return when.promise(function(resolve, reject) {
+      serialport.close( function(err){
+        if(err){ return reject(err); }
+        return resolve();
+      });
+    });
+  }
+
+  var promise = this.signoff()
+    .then(_close());
+  return nodefn.bindCallback(promise, cb);
+};
+
 Protocol.prototype.enterProgramming = function(cb){
   var serialport = this._serial;
 

--- a/index.js
+++ b/index.js
@@ -7,92 +7,97 @@ var nodefn = require('when/node');
 function Protocol(options){
   var self = this;
 
+  var transport = options.transport;
+
   //todo fail on no options.path
-
+  var path = options.path;
   var opts = options.options || { baudrate: 200 };
+  var TransportCtor = SerialPort;
+  if(transport){
+    path = transport.path;
+    opts = transport.options;
+    TransportCtor = transport.constructor;
+  }
 
-  this._serial = options.serialport || new SerialPort(options.path, opts, false);
+  // if we receive a SerialPort in options, we don't want to mutate it
+  // so we use this pattern to copy and promisify it
+  function Transport(){
+    TransportCtor.apply(this, arguments);
+  }
+  Transport.prototype = nodefn.liftAll(TransportCtor.prototype);
+
+  this._transport = new Transport(path, opts, false);
 
   this._queue = null;
 
-  this._serial.on('data', function(chunk){
+  this._transport.on('data', function(chunk){
     if(typeof self._queue === 'function'){
       self._queue(chunk);
     }
   });
 }
 
-//if opened before a bootload is attempted, opened at 200 intead of 9600
-Protocol.prototype.open = function(options, cb){
-  var serialport = this._serial;
+Protocol.prototype._setDtr = function(cb){
+  var transport = this._transport;
 
-  function _open(){
-    return when.promise(function(resolve, reject) {
-      serialport.open( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var promise = transport.set({ dtr: false });
 
-  function onChunk(data) {
-    self.emit('data', data);
-  }
-
-  self._onResponse(onChunk);
-
-  var promise = _open();
   return nodefn.bindCallback(promise, cb);
 };
 
-Protocol.prototype.close = function(cb){
-  var serialport = this._serial;
+Protocol.prototype._clrDtr = function(cb){
+  var transport = this._transport;
 
-  function _close(){
-    return when.promise(function(resolve, reject) {
-      serialport.close( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var promise = transport.set({ dtr: true });
 
-  var promise = this.signoff()
-    .then(_close());
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype._setBrk = function(cb){
+  var transport = this._transport;
+
+  var brkBit = new Buffer([0x00]);
+
+  var promise = transport.write(brkBit);
+
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype._clrBrk = function(cb){
+  var transport = this._transport;
+
+  var promise = transport.update({ baudRate: 9600 });
+
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.enterProgramming = function(cb){
-  var serialport = this._serial;
+  var self = this;
+  var transport = this._transport;
 
-  function _open(){
-    return when.promise(function(resolve, reject) {
-      serialport.open( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
+  var promise = transport.open()
+    .then(function(){
+      return self._setBrk();
+    })
+    .then(function(){
+      return self.reset();
+    })
+    .delay(100) //need to wait for the setbrk byte to get out on the line
+    .then(function(){
+      return self._clrBrk();
     });
-  }
 
-  var promise = _open()
-    .then(this.reset.bind(this));
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.exitProgramming = function(cb){
-  var serialport = this._serial;
-
-  function _close(){
-    return when.promise(function(resolve, reject) {
-      serialport.close( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var transport = this._transport;
 
   var promise = this.signoff()
-    .then(_close());
+    .then(function(){
+      return transport.close();
+    });
+
   return nodefn.bindCallback(promise, cb);
 };
 
@@ -102,7 +107,7 @@ Protocol.prototype._onResponse = function(fn){
 
 Protocol.prototype.send = function send(data, cb){
   var self = this;
-  var serial = this._serial;
+  var serial = this._transport;
 
   var responseLength = data.length + 1;
 
@@ -133,63 +138,23 @@ Protocol.prototype.send = function send(data, cb){
 };
 
 Protocol.prototype.reset = function reset(cb){
-  var serial = this._serial;
+  var self = this;
 
-  function setDtr(){
-    return when.promise(function(resolve, reject) {
-      serial.set({dtr: false}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  function clrDtr(){
-    return when.promise(function(resolve, reject) {
-      serial.set({dtr: true}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  function setBrk(){
-    return when.promise(function(resolve, reject) {
-      serial.write(new Buffer([0x00]), function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  function clrBrk(){
-    return when.promise(function(resolve, reject) {
-      serial.update({baudRate: 9600}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  var promise = setBrk()
-    .then(setDtr)
+  var promise = this._setDtr()
     .delay(2)
-    .then(clrDtr)
-    .delay(100) //need to wait for the setbrk byte to get out on the line
-    .then(clrBrk);
+    .then(function(){
+      return self._clrDtr();
+    });
 
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.signoff = function signoff(cb){
-  var serial = this._serial;
+  var transport = this._transport;
 
-  var promise = when.promise(function(resolve, reject) {
-    serial.write(new Buffer([0]), function(err){
-      if(err){ return reject(err); }
-      return resolve();
-    });
-  });
+  var signoffBit = new Buffer([0]);
+
+  var promise = transport.write(signoffBit);
 
   return nodefn.bindCallback(promise, cb);
 };

--- a/index.js
+++ b/index.js
@@ -3,20 +3,63 @@
 var SerialPort = require('serialport').SerialPort;
 var when = require('when');
 var nodefn = require('when/node');
-var util = require('util');
 
-function BS2SP(path, options, openImmediately, callback){
-  SerialPort.call(this, path, options, openImmediately, callback);
-}
-util.inherits(BS2SP, SerialPort);
-
-
-BS2SP.prototype.reset = function reset(cb){
+function Protocol(options){
   var self = this;
+
+  this._serial = options.serialport || new SerialPort(options.path, options.options);
+
+  this._queue = null;
+
+  this._serial.on('data', function(chunk){
+    if(typeof self._queue === 'function'){
+      self._queue(chunk);
+    }
+  });
+}
+
+Protocol.prototype._onResponse = function(fn){
+  this._queue = fn;
+};
+
+Protocol.prototype.send = function send(data, cb){
+  var self = this;
+  var serial = this._serial;
+
+  var responseLength = data.length + 1;
+
+  var promise = when.promise(function(resolve, reject) {
+
+    var buffer = new Buffer(0);
+    function onChunk(chunk) {
+      buffer = Buffer.concat([buffer, chunk]);
+      if (buffer.length > responseLength) {
+        // or ignore after
+        return reject(new Error('buffer overflow ' + buffer.length + ' > ' + responseLength));
+      }
+      if (buffer.length === responseLength) {
+        resolve(buffer[data.length]);
+      }
+    }
+
+    self._onResponse(onChunk);
+
+    serial.write(data, function (writeError) {
+      if (writeError) {
+        return reject(writeError);
+      }
+    });
+  });
+
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype.reset = function reset(cb){
+  var serial = this._serial;
 
   function setDtr(){
     return when.promise(function(resolve, reject) {
-      self.set({dtr: false}, function(err){
+      serial.set({dtr: false}, function(err){
         if(err){ return reject(err); }
         return resolve();
       });
@@ -25,7 +68,7 @@ BS2SP.prototype.reset = function reset(cb){
 
   function clrDtr(){
     return when.promise(function(resolve, reject) {
-      self.set({dtr: true}, function(err){
+      serial.set({dtr: true}, function(err){
         if(err){ return reject(err); }
         return resolve();
       });
@@ -34,7 +77,7 @@ BS2SP.prototype.reset = function reset(cb){
 
   function setBrk(){
     return when.promise(function(resolve, reject) {
-      self.write(new Buffer([0x00]), function(err){
+      serial.write(new Buffer([0x00]), function(err){
         if(err){ return reject(err); }
         return resolve();
       });
@@ -43,7 +86,7 @@ BS2SP.prototype.reset = function reset(cb){
 
   function clrBrk(){
     return when.promise(function(resolve, reject) {
-      self.update({baudRate: 9600}, function(err){
+      serial.update({baudRate: 9600}, function(err){
         if(err){ return reject(err); }
         return resolve();
       });
@@ -51,13 +94,26 @@ BS2SP.prototype.reset = function reset(cb){
   }
 
   var promise = setBrk()
-  .then(setDtr)
-  .delay(2)
-  .then(clrDtr)
-  .delay(100) //need to wait for the setbrk byte to get out on the line
-  .then(clrBrk);
+    .then(setDtr)
+    .delay(2)
+    .then(clrDtr)
+    .delay(100) //need to wait for the setbrk byte to get out on the line
+    .then(clrBrk);
 
   return nodefn.bindCallback(promise, cb);
 };
 
-module.exports = BS2SP;
+Protocol.prototype.signoff = function signoff(cb){
+  var serial = this._serial;
+
+  var promise = when.promise(function(resolve, reject) {
+    serial.write(new Buffer([0]), function(err){
+      if(err){ return reject(err); }
+      return resolve();
+    });
+  });
+
+  return nodefn.bindCallback(promise, cb);
+};
+
+module.exports = Protocol;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "lodash": "^3.6.0",
     "serialport": "jacobrosenthal/node-serialport#update",
     "when": "^3.7.2"
   },


### PR DESCRIPTION
The way @monteslu referred to this was "protocol".

Below is my understanding and thoughts on the API abstractions:
- Transport: implements `.write` and `on('data')` - e.g. node-serialport, browser-serialport
- Protocol: implements mid level abstractions like `.reset`, `.signoff` and `.send` - the protocol is tied to a transport in most cases.  This project could be renamed to `bs2-serial-protocol`
- Programmer: implements the high level abstractions such as `.identify`, `.challenge`, and `.bootload` - the programmer receives a protocol and calls methods on it for the programming lifecycle.

@monteslu @jacobrosenthal thoughts?
