### PR TITLE
Handling of transport close before trying to open & other general cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,92 +7,97 @@ var nodefn = require('when/node');
 function Protocol(options){
   var self = this;
 
+  var transport = options.transport;
+
   //todo fail on no options.path
-
+  var path = options.path;
   var opts = options.options || { baudrate: 200 };
+  var TransportCtor = SerialPort;
+  if(transport){
+    path = transport.path;
+    opts = transport.options;
+    TransportCtor = transport.constructor;
+  }
 
-  this._serial = options.serialport || new SerialPort(options.path, opts, false);
+  // if we receive a SerialPort in options, we don't want to mutate it
+  // so we use this pattern to copy and promisify it
+  function Transport(){
+    TransportCtor.apply(this, arguments);
+  }
+  Transport.prototype = nodefn.liftAll(TransportCtor.prototype);
+
+  this._transport = new Transport(path, opts, false);
 
   this._queue = null;
 
-  this._serial.on('data', function(chunk){
+  this._transport.on('data', function(chunk){
     if(typeof self._queue === 'function'){
       self._queue(chunk);
     }
   });
 }
 
-//if opened before a bootload is attempted, opened at 200 intead of 9600
-Protocol.prototype.open = function(options, cb){
-  var serialport = this._serial;
+Protocol.prototype._setDtr = function(cb){
+  var transport = this._transport;
 
-  function _open(){
-    return when.promise(function(resolve, reject) {
-      serialport.open( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var promise = transport.set({ dtr: false });
 
-  function onChunk(data) {
-    self.emit('data', data);
-  }
-
-  self._onResponse(onChunk);
-
-  var promise = _open();
   return nodefn.bindCallback(promise, cb);
 };
 
-Protocol.prototype.close = function(cb){
-  var serialport = this._serial;
+Protocol.prototype._clrDtr = function(cb){
+  var transport = this._transport;
 
-  function _close(){
-    return when.promise(function(resolve, reject) {
-      serialport.close( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var promise = transport.set({ dtr: true });
 
-  var promise = this.signoff()
-    .then(_close());
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype._setBrk = function(cb){
+  var transport = this._transport;
+
+  var brkBit = new Buffer([0x00]);
+
+  var promise = transport.write(brkBit);
+
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype._clrBrk = function(cb){
+  var transport = this._transport;
+
+  var promise = transport.update({ baudRate: 9600 });
+
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.enterProgramming = function(cb){
-  var serialport = this._serial;
+  var self = this;
+  var transport = this._transport;
 
-  function _open(){
-    return when.promise(function(resolve, reject) {
-      serialport.open( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
+  var promise = transport.open()
+    .then(function(){
+      return self._setBrk();
+    })
+    .then(function(){
+      return self.reset();
+    })
+    .delay(100) //need to wait for the setbrk byte to get out on the line
+    .then(function(){
+      return self._clrBrk();
     });
-  }
 
-  var promise = _open()
-    .then(this.reset.bind(this));
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.exitProgramming = function(cb){
-  var serialport = this._serial;
-
-  function _close(){
-    return when.promise(function(resolve, reject) {
-      serialport.close( function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var transport = this._transport;
 
   var promise = this.signoff()
-    .then(_close());
+    .then(function(){
+      return transport.close();
+    });
+
   return nodefn.bindCallback(promise, cb);
 };
 
@@ -102,7 +107,7 @@ Protocol.prototype._onResponse = function(fn){
 
 Protocol.prototype.send = function send(data, cb){
   var self = this;
-  var serial = this._serial;
+  var serial = this._transport;
 
   var responseLength = data.length + 1;
 
@@ -133,63 +138,23 @@ Protocol.prototype.send = function send(data, cb){
 };
 
 Protocol.prototype.reset = function reset(cb){
-  var serial = this._serial;
+  var self = this;
 
-  function setDtr(){
-    return when.promise(function(resolve, reject) {
-      serial.set({dtr: false}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  function clrDtr(){
-    return when.promise(function(resolve, reject) {
-      serial.set({dtr: true}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  function setBrk(){
-    return when.promise(function(resolve, reject) {
-      serial.write(new Buffer([0x00]), function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  function clrBrk(){
-    return when.promise(function(resolve, reject) {
-      serial.update({baudRate: 9600}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
-
-  var promise = setBrk()
-    .then(setDtr)
+  var promise = this._setDtr()
     .delay(2)
-    .then(clrDtr)
-    .delay(100) //need to wait for the setbrk byte to get out on the line
-    .then(clrBrk);
+    .then(function(){
+      return self._clrDtr();
+    });
 
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.signoff = function signoff(cb){
-  var serial = this._serial;
+  var transport = this._transport;
 
-  var promise = when.promise(function(resolve, reject) {
-    serial.write(new Buffer([0]), function(err){
-      if(err){ return reject(err); }
-      return resolve();
-    });
-  });
+  var signoffBit = new Buffer([0]);
+
+  var promise = transport.write(signoffBit);
 
   return nodefn.bindCallback(promise, cb);
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "lodash": "^3.6.0",
     "serialport": "jacobrosenthal/node-serialport#update",
     "when": "^3.7.2"
   },


### PR DESCRIPTION
Since I was having a hard time explaining my thoughts on how this could work, I wrote code that could show what I was thinking.

I also have an example of blink utilizing this code in the bs2-programmer repo that I will be PRing for review with this one.

If we are given a `transport` by the end user, we should assume it is open and try to close it (with graceful error handling).  The code here assumes the user will be a good citizen and not try to open that transport again else we would have to be very aggressive in checking the `isOpen` method of `customTransport`.

I've also done some neat things with a `Transport` constructor that allows us to promisify it without mutating the end user's transport.

I've commented the sections I thought were a bit strange, but this is how I envision us maintaining the state of the transport in this middle layer abstraction.

This can probably be cleaned up some more.
