### PR TITLE
Implement user-configurable baud rate, add byte ignore feature to stream parser.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ var TransmitStreamParser = require('./lib/transmit-stream-parser');
 
 var openRegexp = new RegExp('Serialport not open.');
 
+var DEFAULT_BAUDRATE = 9600;
+
 function closeCustomTransport(customTransport){
   return when.promise(function(resolve, reject){
     customTransport.close(function(err){
@@ -46,7 +48,7 @@ function Protocol(options){
 
   //todo fail on no options.path
   var path = options.path;
-  var opts = options.options || { baudrate: 9600 };
+  var opts = options.options || { baudrate: DEFAULT_BAUDRATE };
   var TransportCtor = SerialPort;
   if(customTransport){
     path = customTransport.path;
@@ -268,6 +270,17 @@ Protocol.prototype.send = function send(data, cb){
   var promise = defer.promise.finally(function(){
     transport.removeListener('data', onChunk);
   });
+
+  return nodefn.bindCallback(promise, cb);
+};
+
+Protocol.prototype.setBaudrate = function(baudrate, cb){
+  var transport = this._transport;
+  var options = this._options.options;
+
+  options.baudrate = baudrate;
+
+  var promise = transport.update({ baudRate: options.baudrate });
 
   return nodefn.bindCallback(promise, cb);
 };

--- a/lib/terminal-stream-parser.js
+++ b/lib/terminal-stream-parser.js
@@ -52,6 +52,7 @@ function combineLinefeed(lastCode, code){
 function StreamParser(){
   this.partial = null;
   this.lastCode = null;
+  this.ignoreBytes = [];
 }
 
 StreamParser.prototype.parseStreamChunk = function(chunk){
@@ -71,6 +72,9 @@ StreamParser.prototype.parseStreamChunk = function(chunk){
       // LF, CR, LF, CR
       this.lastCode = null;
       continue;
+    }else if(this.ignoreBytes.length > 0 && char === this.ignoreBytes[0]){
+      //ignore character, remove from ignore buffer
+      this.ignoreBytes.shift();
     }else if(eventCodes[char] != null){
       // finalize the current text event before we create the special event
       addTextEvent(events, str);
@@ -84,6 +88,10 @@ StreamParser.prototype.parseStreamChunk = function(chunk){
   // finalize any trailing text into an event
   addTextEvent(events, str);
   return events;
+};
+
+StreamParser.prototype.ignoreCharacter = function(char){
+  this.ignoreBytes.push(char);
 };
 
 StreamParser.prototype.handleEvent = function(eventList, evt){


### PR DESCRIPTION
#### What's this PR do?

Adds `setBaudrate` which allows for custom baud rates in `SEROUT` and other uses. Byte ignore feature in terminal allows for echo elimination in a future release.
#### How should this be manually tested?

Used `board.setBaudrate(x)` in Parallax-IDE to verify baud rate setting works and does not interfere with break functionality.
#### What are the relevant tickets?

parallaxinc/Parallax-IDE/issues/77
