### PR TITLE
Add transmit event with stream parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,10 +273,10 @@ Protocol.prototype.send = function send(data, cb){
 Protocol.prototype.write = function(data, cb){
   var transport = this._transport;
 
-  var promise = transport.write(data);
-
   var transmitEvents = this._transmit.parseStreamChunk(data);
   this.emit('transmit', transmitEvents);
+
+  var promise = transport.write(data);
 
   return nodefn.bindCallback(promise, cb);
 };

--- a/lib/transmit-stream-parser.js
+++ b/lib/transmit-stream-parser.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var eventCodes = {
+  8: 'backspace'
+};
+
+function addTextEvent(eventList, text) {
+  if(text.length > 0){
+    eventList.push({
+      type: 'text',
+      data: text
+    });
+  }
+}
+
+function addEvent(eventList, type, data) {
+  eventList.push({
+    type: type,
+    data: data
+  });
+}
+
+function combineLinefeed(lastCode, code){
+  return (lastCode === 10 && code === 13) || (lastCode === 13 && code === 10);
+}
+
+function StreamParser(){
+  this.lastCode = null;
+}
+
+StreamParser.prototype.parseStreamChunk = function(chunk){
+  var events = [];
+  var str = '';
+  for(var idx = 0; idx < chunk.length; idx++){
+    var char = chunk[idx];
+    if(combineLinefeed(this.lastCode, char)){
+      this.lastCode = char;
+      //do nothing, allow previous linefeed event to handle this
+      continue;
+    } else if(char === 10 || char === 13){
+      str += '\n';
+    } else if(eventCodes[char] != null){
+      // finalize the current text event before we create the special event
+      addTextEvent(events, str);
+      str = '';
+      addEvent(events, eventCodes[char]);
+    } else if(char <= 31 || (char >= 128 && char <= 159)){
+      str += ' ';
+    } else {
+      str += String.fromCharCode(char);
+    }
+    this.lastCode = char;
+  }
+  // finalize any trailing text into an event
+  addTextEvent(events, str);
+  return events;
+};
+
+module.exports = StreamParser;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "main": "index.js",
   "files": [
     "index.js",
-    "lib/terminal-stream-parser.js"
+    "lib/terminal-stream-parser.js",
+    "lib/transmit-stream-parser.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
#### What's this PR do?

This PR adds a stream parser for transmit terminal events in the same pattern as console read events. All data sent via transmit pane is parsed and emitted back as `transmit` events, which can be displayed in the UI.
#### What are the relevant tickets?

parallaxinc/Parallax-IDE/pull/183
