### PR TITLE
Refactor Transport code into separate class, use new setBreak/clearBreak API

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,14 +37,14 @@ Protocol.prototype.isOpen = function isOpen(){
 
 Protocol.prototype.open = function(cb){
   if(this.isOpen()){
-    return when.resolve(true);
+    return nodefn.bindCallback(when.resolve(), cb);
   }
   return nodefn.bindCallback(this._transport.open(), cb);
 };
 
 Protocol.prototype.close = function(cb){
   if(!this.isOpen()){
-    return when.resolve(true);
+    return nodefn.bindCallback(when.resolve(), cb);
   }
   return nodefn.bindCallback(this._transport.close(), cb);
 };

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ Protocol.prototype.open = function(cb){
 
 Protocol.prototype.close = function(cb){
   var promise;
-  if(this.isOpen()){
+  if(!this.isOpen()){
     promise = when.resolve();
   }else{
     promise = this._transport.close();

--- a/index.js
+++ b/index.js
@@ -5,174 +5,54 @@ var util = require('util');
 var when = require('when');
 var nodefn = require('when/node');
 var reemit = require('re-emitter');
-var cloneDeep = require('lodash/lang/cloneDeep');
-var Serial = require('serialport');
-var SerialPort = Serial.SerialPort;
 var EventEmitter = require('events').EventEmitter;
+
+var Transport = require('./transport');
 
 var TerminalStreamParser = require('./lib/terminal-stream-parser');
 var TransmitStreamParser = require('./lib/transmit-stream-parser');
 
-var openRegexp = new RegExp('Serialport not open.');
-
-function closeCustomTransport(customTransport){
-  return when.promise(function(resolve, reject){
-    customTransport.close(function(err){
-      if(err && !openRegexp.test(err.message)){
-        // reject if error is not "Serialport not open."
-        return reject(err);
-      }
-
-      resolve();
-    });
-  });
-}
-
-var toLift = ['open', 'close', 'set', 'update', 'write'];
-
-// only lift the functions we use
-function lifter(result, lifted, name){
-  if(toLift.indexOf(name) !== -1){
-    result[name] = lifted;
-  }
-
-  return result;
-}
-
 function Protocol(options){
-  var customTransport = options.transport;
-
   EventEmitter.call(this);
-
-  //todo fail on no options.path
-  var path = options.path;
-  var opts = options.options || { baudrate: 9600 };
-  var TransportCtor = SerialPort;
-  if(customTransport){
-    path = customTransport.path;
-    opts = customTransport.options;
-    TransportCtor = customTransport.constructor;
-  }
 
   this._terminal = new TerminalStreamParser();
   this._transmit = new TransmitStreamParser();
 
-  // if we receive a SerialPort in options, we don't want to mutate it
-  // so we use this pattern to copy and promisify it
-  function Transport(){
-    TransportCtor.apply(this, arguments);
+  var TransportCtor = options.transport || Transport;
 
-    if(customTransport){
-      this.options.dataCallback = function(data){
-        customTransport.options.parser(this, data);
-      }.bind(this);
-    }
-  }
-  util.inherits(Transport, TransportCtor);
-  // passing Transport.prototype to the last argument uses that as the accumulator
-  nodefn.liftAll(TransportCtor.prototype, lifter, Transport.prototype);
-
-  this._isOpen = false;
-  var transport = this._transport = new Transport(path, opts, false);
-  // saving the original options from the transport to allow
-  this._options = cloneDeep({
-    path: transport.path,
-    options: transport.options,
+  this._options = {
     echo: options.echo || false
-  });
+  };
 
-  reemit(transport, this, ['open', 'close']);
+  this._transport = new TransportCtor(_.omit(options, 'transport'));
 
-  // if we are given a transport, attempt to close it
-  if(customTransport){
-    // make this a promise for simpler code paths
-    this._originalTransportClosed = closeCustomTransport(customTransport);
-  } else {
-    this._originalTransportClosed = when.resolve();
-  }
+  reemit(this._transport, this, ['open', 'close', 'data']);
 }
 
 util.inherits(Protocol, EventEmitter);
 
-Protocol.prototype._open = function(cb){
-  var self = this;
-  var transport = this._transport;
+Protocol.prototype.isOpen = function isOpen(){
+  return this._transport.isOpen();
+};
 
-  var promise;
-  if(this._isOpen){
-    promise = when.reject(new Error('Transport already open.'));
-  } else {
-    promise = transport.open()
-      .tap(function(){
-        self._isOpen = true;
-      });
+Protocol.prototype.open = function(cb){
+  if(this.isOpen()){
+    return when.resolve(true);
   }
-
-  return nodefn.bindCallback(promise, cb);
+  return nodefn.bindCallback(this._transport.open(), cb);
 };
 
-Protocol.prototype._close = function(cb){
-  var self = this;
-  var transport = this._transport;
-
-  function onClose(){
-    self._isOpen = false;
+Protocol.prototype.close = function(cb){
+  if(!this.isOpen()){
+    return when.resolve(true);
   }
-
-  var promise = transport.close()
-    .tap(onClose)
-    .catch(function(err){
-      if(err && !openRegexp.test(err.message)){
-        // rethrow error if it is not "Serialport not open."
-        throw err;
-      }
-
-      onClose();
-    });
-
-  return nodefn.bindCallback(promise, cb);
-};
-
-Protocol.prototype._setDtr = function(cb){
-  var transport = this._transport;
-
-  var promise = transport.set({ dtr: false });
-
-  return nodefn.bindCallback(promise, cb);
-};
-
-Protocol.prototype._clrDtr = function(cb){
-  var transport = this._transport;
-
-  var promise = transport.set({ dtr: true });
-
-  return nodefn.bindCallback(promise, cb);
-};
-
-Protocol.prototype._setBrk = function(cb){
-  var transport = this._transport;
-
-  var brkBit = new Buffer([0x00]);
-
-  var promise = transport.update({ baudRate: 200 })
-    .then(function(){
-      return transport.write(brkBit);
-    });
-
-  return nodefn.bindCallback(promise, cb);
-};
-
-Protocol.prototype._clrBrk = function(cb){
-  var transport = this._transport;
-  var options = this._options.options;
-
-  var promise = transport.update({ baudRate: options.baudrate });
-
-  return nodefn.bindCallback(promise, cb);
+  return nodefn.bindCallback(this._transport.close(), cb);
 };
 
 Protocol.prototype.enterProgramming = function(options, cb){
   var self = this;
+  var transport = this._transport;
+
   if(typeof options === 'function'){
     cb = options;
     options = {};
@@ -180,24 +60,30 @@ Protocol.prototype.enterProgramming = function(options, cb){
     options = options || {};
   }
 
-  var promise = this._originalTransportClosed
+  var promise = transport.open()
     .then(function(){
-      if(self._isOpen){
-        return self._close();
+      transport.autoRecover = false;
+      return transport.setBreak();
+    })
+    .then(function(){
+      return transport.set({ dtr: false });
+    })
+    .then(function(){
+      return transport.set({ dtr: true }).delay(60);
+    })
+    .then(function(){
+      return transport.clearBreak();
+    })
+    .then(function(){
+      transport.autoRecover = true;
+      if(transport.isPaused()){
+        return transport.unpause();
+      }else{
+        return when.resolve(true);
       }
     })
     .then(function(){
-      return self._open();
-    })
-    .then(function(){
-      return self._setBrk();
-    })
-    .then(function(){
-      return self.reset();
-    })
-    .delay(100) //need to wait for the setbrk byte to get out on the line
-    .then(function(){
-      return self._clrBrk();
+      return transport.flush();
     });
 
   return nodefn.bindCallback(promise, cb);
@@ -205,6 +91,7 @@ Protocol.prototype.enterProgramming = function(options, cb){
 
 Protocol.prototype.exitProgramming = function(options, cb){
   var self = this;
+  var transport = this._transport;
 
   if(typeof options === 'function'){
     cb = options;
@@ -217,11 +104,18 @@ Protocol.prototype.exitProgramming = function(options, cb){
     .then(function(){
       self._terminal.clearIgnore();
       if(!options.keepOpen){
-        return self._close();
+        return transport.close();
       }
       if(options.listen){
         return self.listenPort();
       }
+    })
+    .otherwise(function(err){
+      //close socket
+      return transport.close()
+        .then(function(){
+          throw err;
+        });
     });
 
   return nodefn.bindCallback(promise, cb);
@@ -232,13 +126,17 @@ Protocol.prototype._emitData = function _emitData(chunk){
 };
 
 Protocol.prototype.listenPort = function listenPort(cb){
-  this._transport.on('data', this._emitData.bind(this));
+  this.on('data', this._emitData.bind(this));
 
   return nodefn.bindCallback(when.resolve(), cb);
 };
 
+Protocol.prototype._write = function write(data){
+  return this._transport.send(data);
+};
+
 Protocol.prototype.send = function send(data, cb){
-  var transport = this._transport;
+  var self = this;
 
   var responseLength = data.length + 1;
 
@@ -247,11 +145,11 @@ Protocol.prototype.send = function send(data, cb){
   var buffer = new Buffer(0);
   function onChunk(chunk){
     buffer = Buffer.concat([buffer, chunk]);
+
     if(buffer.length < responseLength){
       // keep buffering
       return;
     }
-
     if (buffer.length > responseLength) {
       // or ignore after
       defer.reject(new Error('buffer overflow ' + buffer.length + ' > ' + responseLength));
@@ -262,65 +160,48 @@ Protocol.prototype.send = function send(data, cb){
     }
   }
 
-  transport.on('data', onChunk);
+  this.on('data', onChunk);
 
-  transport.write(data)
+  this._write(data)
     .catch(defer.reject);
 
   var promise = defer.promise.finally(function(){
-    transport.removeListener('data', onChunk);
+    self.removeListener('data', onChunk);
   });
 
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.write = function(data, cb){
-  var transport = this._transport;
-
   var transmitEvents = this._transmit.parseStreamChunk(data);
   this.emit('transmit', transmitEvents);
 
   if(!this._options.echo){
     this._terminal.ignore(data);
   }
-
-  var promise = transport.write(data);
+  var promise = this._write(data);
 
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.reset = function reset(cb){
-  var self = this;
+  var transport = this._transport;
 
-  var promise = this._setDtr()
+  var promise = transport.set({ dtr: true })
     .delay(2)
     .then(function(){
-      return self._clrDtr();
+      return transport.set({ dtr: false });
     });
 
   return nodefn.bindCallback(promise, cb);
 };
 
 Protocol.prototype.signoff = function signoff(cb){
-  var transport = this._transport;
-
   var signoffBit = new Buffer([0]);
 
-  var promise = transport.write(signoffBit);
+  var promise = this._write(signoffBit);
 
   return nodefn.bindCallback(promise, cb);
-};
-
-Protocol.prototype.open = function open(cb){
-  return this._open(cb);
-};
-
-Protocol.prototype.close = function close(cb){
-  if(this._isOpen){
-    return this._close(cb);
-  }else{
-    return nodefn.bindCallback(when.resolve(), cb);
-  }
 };
 
 Protocol.prototype.setEcho = function setEcho(echo){
@@ -329,11 +210,7 @@ Protocol.prototype.setEcho = function setEcho(echo){
 };
 
 Protocol.listPorts = function(cb){
-  var results = nodefn.call(Serial.list)
-    .then(function(ports){
-      return _.pluck(ports, 'comName');
-    });
-  return nodefn.bindCallback(results, cb);
+  return nodefn.bindCallback(Transport.listPorts(), cb);
 };
 
 module.exports = Protocol;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "transport.js",
     "lib/terminal-stream-parser.js",
     "lib/transmit-stream-parser.js"
   ],
@@ -25,7 +26,6 @@
   "dependencies": {
     "lodash": "^3.6.0",
     "re-emitter": "^1.1.1",
-    "serialport": "jacobrosenthal/node-serialport#update",
     "when": "^3.7.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "contributors": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jacobrosenthal/bs2-serialport"
+    "url": "https://github.com/irkenjs/bs2-serial-protocol"
   },
   "license": "MIT",
   "engines": {
@@ -20,8 +20,7 @@
     "lib/transmit-stream-parser.js"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "npm rebuild --build-from-source"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "lodash": "^3.6.0",

--- a/transport.js
+++ b/transport.js
@@ -1,0 +1,220 @@
+'use strict';
+
+var _ = require('lodash');
+var util = require('util');
+var when = require('when');
+var EventEmitter = require('events').EventEmitter;
+
+function resolveCallback(resolve, reject){
+  return function(result){
+    if(chrome.runtime.lastError){
+      console.log('error', chrome.runtime.lastError);
+      reject(new Error(chrome.runtime.lastError.message));
+    }else{
+      resolve(result);
+    }
+  };
+}
+
+function promisify(api){
+  return _.reduce(api, function(result, method, name){
+    if(_.isFunction(method)){
+      result[name] = function(){
+        var args = _.toArray(arguments);
+        return when.promise(function(resolve, reject){
+          method.apply(api, args.concat(resolveCallback(resolve, reject)));
+        });
+      };
+    }
+    return result;
+  }, {});
+}
+
+var serial = promisify(chrome.serial);
+
+function toBuffer(ab) {
+  var buffer = new Buffer(ab.byteLength);
+  var view = new Uint8Array(ab);
+  for (var i = 0; i < buffer.length; ++i) {
+      buffer[i] = view[i];
+  }
+  return buffer;
+}
+
+// Convert string to ArrayBuffer
+function str2ab(str) {
+  var buf = new ArrayBuffer(str.length);
+  var bufView = new Uint8Array(buf);
+  for (var i = 0; i < str.length; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+
+// Convert buffer to ArrayBuffer
+function buffer2ArrayBuffer(buffer) {
+  var buf = new ArrayBuffer(buffer.length);
+  var bufView = new Uint8Array(buf);
+  for (var i = 0; i < buffer.length; i++) {
+    bufView[i] = buffer[i];
+  }
+  return buf;
+}
+
+
+function Transport(options) {
+  EventEmitter.call(this);
+
+  this._connectionId = -1;
+  this._paused = false;
+  this.autoRecover = true;
+
+  this._closing = false;
+  this._resuming = false;
+
+  if(!options.path){
+    throw new Error('Not path in Transport options');
+  }
+
+  this._options = _.cloneDeep(options);
+
+  this.onError = this._onError.bind(this);
+  this.onReceive = this._onReceive.bind(this);
+}
+
+util.inherits(Transport, EventEmitter);
+
+Transport.prototype._onReceive = function onReceive(info){
+  this.emit('data', toBuffer(info.data));
+};
+
+Transport.prototype._onError = function onError(err){
+  var self = this;
+  console.log('onReceiveError', err, chrome.runtime.lastError, this._connectionId);
+
+  switch(err.error){
+    case 'disconnected':
+    case 'device_lost':
+      if(self._connectionId >= 0){
+        //hard error, close connection
+        self.close();
+      }
+      break;
+    case 'timeout':
+      //ignore, timeout will not pause connection
+      break;
+    case 'frame_error':
+    case 'system_error':
+    case 'overrun':
+    case 'buffer_overflow':
+    case 'parity_error':
+    case 'break':
+      self._paused = true;
+      if(self.autoRecover){
+        //attempt to unpause automatically
+        self.unpause();
+      }
+      break;
+  }
+};
+
+Transport.prototype.isOpen = function isOpen(){
+  return this._connectionId >= 0;
+};
+
+Transport.prototype.isPaused = function isPaused(){
+  return this._paused;
+};
+
+Transport.prototype.open = function(){
+  if(this.isOpen()){
+    return when.resolve(true);
+  }
+
+  var self = this;
+  var path = this._options.path;
+  var opts = {
+    bitrate: this._options.baudrate || 9600
+  };
+
+  return serial.connect(path, opts)
+    .then(function(connInfo){
+      self._closing = false;
+      self._connectionId = connInfo.connectionId;
+      chrome.serial.onReceiveError.addListener(self.onError);
+      chrome.serial.onReceive.addListener(self.onReceive);
+      self.emit('open');
+    });
+};
+
+Transport.prototype.close = function(){
+  var self = this;
+
+  self._closing = serial.disconnect(self._connectionId)
+    .ensure(function(){
+      self._closing = false;
+      self._connectionId = -1;
+      chrome.serial.onReceiveError.removeListener(self.onError);
+      chrome.serial.onReceive.removeListener(self.onReceive);
+      self.emit('close');
+    });
+
+  return self._closing;
+};
+
+Transport.prototype.set = function(options){
+  return serial.setControlSignals(this._connectionId, options);
+};
+
+Transport.prototype.setBreak = function(){
+  return serial.setBreak(this._connectionId);
+};
+
+Transport.prototype.clearBreak = function(){
+  return serial.clearBreak(this._connectionId);
+};
+
+Transport.prototype.flush = function(){
+  return serial.flush(this._connectionId);
+};
+
+Transport.prototype.pause = function(){
+  var self = this;
+  return serial.setPaused(self._connectionId, true)
+    .then(function(){
+      self._paused = true;
+      self._resuming = false;
+    });
+};
+
+Transport.prototype.unpause = function(){
+  var self = this;
+  self._resuming = serial.setPaused(self._connectionId, false)
+    .then(function(){
+      self._paused = false;
+      self._resuming = false;
+    });
+  return self._resuming;
+};
+
+Transport.prototype.send = function write(data){
+  var self = this;
+
+  if (typeof data === 'string') {
+    data = str2ab(buffer);
+  }
+  if (data instanceof ArrayBuffer === false) {
+    data = buffer2ArrayBuffer(data);
+  }
+
+  return serial.send(self._connectionId, data);
+};
+
+Transport.listPorts = function(){
+  return serial.getDevices()
+    .then(function(devices){
+      return _.pluck(devices, 'path');
+    });
+};
+
+module.exports = Transport;

--- a/transport.js
+++ b/transport.js
@@ -69,7 +69,6 @@ function Transport(options) {
   this._paused = false;
   this.autoRecover = true;
 
-  this._closing = false;
   this._resuming = false;
 
   if(!options.path){
@@ -138,7 +137,6 @@ Transport.prototype.open = function(){
 
   return serial.connect(path, opts)
     .then(function(connInfo){
-      self._closing = false;
       self._connectionId = connInfo.connectionId;
       chrome.serial.onReceiveError.addListener(self.onError);
       chrome.serial.onReceive.addListener(self.onReceive);
@@ -149,16 +147,13 @@ Transport.prototype.open = function(){
 Transport.prototype.close = function(){
   var self = this;
 
-  self._closing = serial.disconnect(self._connectionId)
+  return serial.disconnect(self._connectionId)
     .ensure(function(){
-      self._closing = false;
       self._connectionId = -1;
       chrome.serial.onReceiveError.removeListener(self.onError);
       chrome.serial.onReceive.removeListener(self.onReceive);
       self.emit('close');
     });
-
-  return self._closing;
 };
 
 Transport.prototype.set = function(options){

--- a/transport.js
+++ b/transport.js
@@ -90,7 +90,6 @@ Transport.prototype._onReceive = function onReceive(info){
 
 Transport.prototype._onError = function onError(err){
   var self = this;
-  console.log('onReceiveError', err, chrome.runtime.lastError, this._connectionId);
 
   switch(err.error){
     case 'disconnected':


### PR DESCRIPTION
#### What's this PR do?

This PR restructures the transport internals in the protocol, simplifying the protocol by extracting the complicated transport-level logic. This also presents a simplified Transport interface that can be replaced by other serial implementations as needed. The updated transport uses the setBreak/clearBreak APIs (45+) instead of the null-byte workaround.
#### What are the important parts of the code?

Protocol now calls into a separate Transport class (`transport.js`). Transport contains all the internal logic for setting break conditions, switching control states, and sending/receiving data.
#### How should this be tested by the reviewer?

Check out the `experimental-break` branch in Parallax-IDE, it has the requisite changes needed to run this branch immediately.
#### What are the relevant tickets?

Closes parallaxinc/Parallax-IDE#144
Related parallaxinc/Parallax-IDE#194
