### PR TITLE
Improve enterProgramming flow to handle generic system errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,7 @@ Protocol.prototype.open = function(cb){
 };
 
 Protocol.prototype.close = function(cb){
-  var promise;
-  if(!this.isOpen()){
-    promise = when.resolve();
-  }else{
-    promise = this._transport.close();
-  }
-  return nodefn.bindCallback(promise, cb);
+  return nodefn.bindCallback(this._transport.close(), cb);
 };
 
 Protocol.prototype.enterProgramming = function(options, cb){
@@ -70,6 +64,14 @@ Protocol.prototype.enterProgramming = function(options, cb){
     .then(function(){
       transport.autoRecover = false;
       return transport.setBreak();
+    })
+    .then(function(){
+      return transport.flush();
+    })
+    .then(function(){
+      if(transport.isPaused()){
+        return transport.unpause();
+      }
     })
     .then(function(){
       return transport.set({ dtr: false });


### PR DESCRIPTION
#### What's this PR do?

This PR fixes an issue where generic `system_error` state in Chrome 45 needs to be manually recovered before changing signal state. This also removes a guard on Protocol.close() which wasn't actually needed.
#### Is any other information necessary to understand this?

Chrome 46 subtly changes how errors are recovered, we didn't need to resume before flipping DTR. This isn't the case in 45, so we need to resume earlier in the `enterProgramming` chain.
