### PR TITLE
Remove listen fn, use terminal flag to determine whether to emit events

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,9 @@ Protocol.prototype.exitProgramming = function(options, cb){
         });
     })
     .ensure(function(){
-      self._terminalEvents = true;
+      if(options.listen){
+        self._terminalEvents = true;
+      }
     });
 
   return nodefn.bindCallback(promise, cb);


### PR DESCRIPTION
#### What's this PR do?

This removes the `listenPort` call and instead automatically disables terminal events during programming stage. This means we no longer need to manually re-enable terminal processing when re-opening the connection.
#### How should this be tested by the reviewer?

Link into Parallax-IDE and verify all terminal functionality continues to work as-is.
#### What are the relevant tickets?

Needed for parallaxinc/Parallax-IDE/issues/79
