### PR TITLE
Make ack optional on send function

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,10 +139,17 @@ Protocol.prototype._emitTerminal = function _emitTerminal(chunk){
   }
 };
 
-Protocol.prototype.send = function send(data, cb){
+Protocol.prototype.send = function send(data, options, cb){
   var self = this;
 
-  var responseLength = data.length + 1;
+  if(typeof options === 'function'){
+    cb = options;
+    options = {};
+  }
+
+  var ackLength = _.get(options, 'ackLength', 1);
+
+  var responseLength = data.length + ackLength;
 
   var defer = when.defer();
 


### PR DESCRIPTION
#### What's this PR do?

This improves the `send` function to allow it to be used in cases where we don't have a chunk ack byte.
#### Is any other information necessary to understand this?

This is important for sending single-byte values during the programming negotiation.
